### PR TITLE
Add Futil-Js Functional Utilities Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Functional programming is a [style of programming](https://wiki.haskell.org/Func
 * [TGrid](https://github.com/samchon/tgrid) - Grid Computing Framework, Network & Thread extension of [TSTL](https://github.com/samchon/tstl), supporting RFC (Remote Function Call).
 * [Ferrum](https://github.com/adobe/ferrum) – Iterator library with support for objects as iterables, lazy evaulation and`pipe()`; implements Traits (from Rust)/Type Classes (from Haskell) in JS
 * [fp-ts](https://gcanti.github.io/fp-ts/) - Typed functional programming in TypeScript
+* [futil-js](https://github.com/smartprocure/futil-js) - A collection of functional utilities that could conceivably be part of a library like lodash/fp, but for some reason or other are not.
 
 ### Data Structures
 


### PR DESCRIPTION
This PR adds `futil-js`: A collection of F(unctional) Util(ities).

Mostly, these are generic utilities that could conceivably be part of a library like lodash/fp, but for some reason or other are not.

**Note**: this is officially endorsed on lodash's website: https://lodash.com/ if you look at:
> Complementary Tools
> futil-js is a set of functional utilities designed to complement lodash