### PR TITLE
Update link to FP Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Use the laws of math instead of always reinventing your own thing. Algebraic!
 
 ### Talk
 
-* [Functional Programming Slack channel](https://fpchat-invite.herokuapp.com/) – Community with a friendly channel for JavaScript as well as many other channels about functional programming in general.
+* [Functional Programming Slack channel](https://fpslack.com/) – Community with a friendly channel for JavaScript as well as many other channels about functional programming in general.
 
 
 ## Contribution


### PR DESCRIPTION
The url for requesting an invite to FP Slack has changed.